### PR TITLE
jirachi: Bump to v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jirachi"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1813afc8d06a3f04b3a390022f22fdf34eb8a0858ae0208ec739b748e2357c1"
+checksum = "cd3774150b53c1d35fda75fe715c4779111be7090bb2dab4a43a83f90efedee0"
 dependencies = [
  "anyhow",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ slog-async = "2.5.0"
 bcrypt = "0.8.2"
 chrono = "0.4.15"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-jirachi = { version = "0.1.7", features = ["collision-resistant"] }
+jirachi = { version = "0.1.8", features = ["collision-resistant"] }
 rocket_cors = "0.5.2"
 regex = "1.3.9"
 


### PR DESCRIPTION
- jirachi v0.1.8 implements key-balancing at database level.